### PR TITLE
Fix README.md references

### DIFF
--- a/2016-04-28/Unit Testing Objective-C with Swift/README.md
+++ b/2016-04-28/Unit Testing Objective-C with Swift/README.md
@@ -2,8 +2,8 @@
 
 I've added two versions of the project I walked through in my presentation. One represents the project before I started refactoring and adding tests, the other represents the final version after refactoring and all tests:
 
-* [TheBodega_First](TheBodega_First/TheBodega.xcodeproj)
-* [TheBodega_Last](TheBodega_Last/TheBodega.xcodeproj)
+* [TheBodega_First](TheBodega_First/)
+* [TheBodega_Last](TheBodega_Last/)
 
 I've also included the code snippets that I used to get from the first to the last version. Each snippet replaces a complete header, implementation or test file. If you want to import the snippets into Xcode you should place them here:
 


### PR DESCRIPTION
From GitHub it makes more sense the markdown links reference the project folders, not the project files. I fixed this in this PR.

/Mikkel